### PR TITLE
Smart Hub 2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# BT Smarthub Device List v.0.1.3
+# BT Smarthub Device List v.0.1.4
 
-Python package allowing for a [BT Smart Hub](https://www.productsandservices.bt.com/broadband/smart-hub/) router to be queried for devices.
+Python package allowing for a [BT Smart Hub or BT Smart Hub 2](https://www.productsandservices.bt.com/broadband/smart-hub/) router to be queried for devices.
 The package will output either all devices stored in the router's memory or just the devices connected at present
 as a list of dicts with the following keys:
   - UserHostName (Device Name)
   - PhysAddress (MAC Address)
   - IPAddress (Last Known IP of Device)
   - Active (Boolean for if the Device is Connected to the Router)
-
+  
+For use with BT Smart Hub 2 set the is_smart_hub2 flag to True
 ### Installation
 ```sh
 $ pip install btsmarthub_devicelist
@@ -17,7 +18,7 @@ $ pip install btsmarthub_devicelist
 
 ```sh
 import btsmarthub_devicelist
-devicelist = btsmarthub_devicelist.get_devicelist(router_ip='192.168.1.254', only_active_devices=True)
+devicelist = btsmarthub_devicelist.get_devicelist(router_ip='192.168.1.254', only_active_devices=True,is_smarthub2=False)
 print(devicelist)
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ as a list of dicts with the following keys:
   - PhysAddress (MAC Address)
   - IPAddress (Last Known IP of Device)
   - Active (Boolean for if the Device is Connected to the Router)
-  
-For use with BT Smart Hub 2 set the is_smart_hub2 flag to True
+
+For use with BT Smart Hub 2 set the is_smart_hub2 flag to True, for a Smart Hub 1 set the flag as False. If you are not sure, leave the flag blank and it will attempt to determine the hub type.
+
 ### Installation
 ```sh
 $ pip install btsmarthub_devicelist
@@ -18,7 +19,7 @@ $ pip install btsmarthub_devicelist
 
 ```sh
 import btsmarthub_devicelist
-devicelist = btsmarthub_devicelist.get_devicelist(router_ip='192.168.1.254', only_active_devices=True,is_smarthub2=False)
+devicelist = btsmarthub_devicelist.get_devicelist(router_ip='192.168.1.254', only_active_devices=True,is_smarthub2=None)
 print(devicelist)
 ```
 

--- a/bt_smarthub_devicelist/__init__.py
+++ b/bt_smarthub_devicelist/__init__.py
@@ -3,5 +3,5 @@ from .btsmarthub_devicelist import get_devicelist
 
 __name__ = "btsmarthub_devicelist"
 __author__ = "Jamie Wolstenholme"
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __license__ = "MIT"

--- a/bt_smarthub_devicelist/btsmarthub2_devicelist.py
+++ b/bt_smarthub_devicelist/btsmarthub2_devicelist.py
@@ -1,0 +1,107 @@
+import logging
+import requests
+import re
+import json
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# string replace to quote all the labels to make it json compliant
+def updateLabel(source, labels):
+    # sort so we do larges matches first removing issues on thinhs like 'ip' used in longer strings
+    labels.sort(key=len, reverse=True)
+    for label in labels:
+        source = source.replace(label + ":", "\"" + label + "\":")
+
+    return source
+
+
+# Filter down to just the same fields as the original library
+def parse_devicelist(device_list):
+    keys = {'UserHostName', 'PhysAddress', 'IPAddress', 'Active'}
+    devices = [{k: v for k, v in i.items() if k in keys} for i in device_list]
+
+    return devices
+
+
+def get_devicelist_smarthub2(router_ip='192.168.1.254', only_active_devices=False):
+
+    # Url that returns js with variable in it showing all the device status
+    request_url = 'http://' + router_ip + '/cgi/cgi_basicMyDevice.js'
+
+    # list of labels that the device returns in the javascript style declaration
+    DEVICE_LABELS = [
+        "mac",
+        "hostname",
+        "ip",
+        "ipv6",
+        "name",
+        "activity",
+        "os",
+        "device",
+        "time_first_seen",
+        "time_last_active",
+        "dhcp_option",
+        "port",
+        "ipv6_ll",
+        "activity_ip",
+        "activity_ipv6_ll",
+        "activity_ipv6",
+        "device_oui",
+        "device_serial",
+        "device_class",
+        "reconnected"
+    ]
+
+
+    try:
+        response = requests.get(request_url)
+    except requests.exceptions.Timeout:
+        _LOGGER.exception("Connection to the router times out")
+        return
+    if response.status_code == 200:
+        body = response.content.decode('utf-8')
+        # body strings are URI encoded
+        body = requests.utils.unquote(body)
+    else:
+        _LOGGER.error("Invalid response from Smart Hub: %s", response)
+
+
+    # and remove all newlines
+    body = body.replace("\n", "")
+
+
+    # pull out the javascript line from the whole file
+    search_expression = re.search(r'known_device_list=(.+?),null', body);
+
+    # my regexx strips the close of the list
+    initial_jscript_array = search_expression.group(1) + ']';
+
+    # to allow json to read this, add quotes around the item labels.
+    initial_jscript_array = updateLabel(initial_jscript_array, DEVICE_LABELS);
+
+    # change the strings to boolean for '0' and '1'
+    initial_jscript_array = initial_jscript_array.replace("'1'", "true")
+    initial_jscript_array = initial_jscript_array.replace("'0'", "false");
+
+    # json likes double not single quotes
+    cleaned_jscript_array = initial_jscript_array.replace("'", "\"")
+
+    # map to the old field names to keep compatibility with hub v1
+    cleaned_jscript_array = cleaned_jscript_array.replace("\"mac\"", "\"PhysAddress\"")
+    cleaned_jscript_array = cleaned_jscript_array.replace("\"activity\"", "\"Active\"")
+    cleaned_jscript_array = cleaned_jscript_array.replace("\"hostname\"", "\"UserHostName\"")
+    cleaned_jscript_array = cleaned_jscript_array.replace("\"ip\"", "\"IPAddress\"")
+
+    # read into obj model using json
+    devices = json.loads(cleaned_jscript_array)
+
+    # shrink them down
+    devices = parse_devicelist(devices)
+
+    # filter when asked
+    if only_active_devices:
+        return [device for device in devices if device.get('Active') ]
+
+    return devices
+

--- a/bt_smarthub_devicelist/btsmarthub_devicelist.py
+++ b/bt_smarthub_devicelist/btsmarthub_devicelist.py
@@ -5,6 +5,7 @@ import math
 import random
 import hashlib
 import logging
+from bt_smarthub_devicelist import btsmarthub2_devicelist
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -13,8 +14,16 @@ def computeMD5hash(hashstring):
     m.update(hashstring.encode('utf-8'))
     return m.hexdigest()
 
+def get_devicelist(router_ip='192.168.1.254', only_active_devices=False, is_smarthub2=False):
 
-def get_devicelist(router_ip='192.168.1.254', only_active_devices=False):
+    if not is_smarthub2:
+        return get_devicelist_smarthub1(router_ip,only_active_devices)
+    else:
+        return btsmarthub2_devicelist.get_devicelist_smarthub2(router_ip,only_active_devices)
+
+
+
+def get_devicelist_smarthub1(router_ip='192.168.1.254', only_active_devices=False):
     parse_active_devices_only = only_active_devices
     authCookieObj = {"req_id": 1,
                      "sess_id": 0,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='btsmarthub_devicelist',
-    version='0.1.2',
+    version='0.1.4',
     packages=['btsmarthub_devicelist'],
     url='https://github.com/jxwolstenholme/bt_smarthub_devicelist',
     license='MIT',

--- a/tests/test_btsmarthub_devicelist.py
+++ b/tests/test_btsmarthub_devicelist.py
@@ -1,0 +1,25 @@
+"""The tests for the btsmarthub devicelist."""
+import unittest
+
+from bt_smarthub_devicelist import btsmarthub_devicelist
+from bt_smarthub_devicelist import btsmarthub2_devicelist
+
+
+class TestBTSmartHub(unittest.TestCase):
+
+    def test_btsmarthub2_getdevicelist(self):
+    # self.asserttrue(btsmarthub2_devicelist.detect_smart_hub2('192.168.1.254', 0.5))
+        connected_devices = btsmarthub_devicelist.get_devicelist('192.168.1.254', True)
+        all_devices = btsmarthub_devicelist.get_devicelist('192.168.1.254', False)
+        self.assertGreaterEqual(len(all_devices), len(connected_devices))
+
+    def test_btsmarthub2_detection_google(self):
+        self.assertFalse(btsmarthub2_devicelist.detect_smart_hub2('www.google.com', 0.5))
+
+    def test_btsmarthub2_detection_google_short_timeout(self):
+        self.assertFalse(btsmarthub2_devicelist.detect_smart_hub2('www.google.com', 0.001))
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestBTSmartHub)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Added smarthub 2 support.

Simple attempt to detect a smarthub 2 vs a smarthub 1. 

Changed signature to :

`def get_devicelist(router_ip='192.168.1.254', only_active_devices=False, is_smarthub2=None):
`
Leaving is_smarthub2 as None means code will attempt to hit what I think is a v2 only URI to detect. If caller knows its a hub 2 (or 1) then we avoid doing the poll each time (I'm not sure how state should be stored after first lookup - in my world that would be a static member var).

Very happy to learn where I'm going wrong - very much a Java dev by trade, so I may be doing terrible things in Python.
