### PR TITLE
Add support for EE smarthub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BT Smarthub Device List v.0.2.1
 
-Python package allowing for a [BT Smart Hub or BT Smart Hub 2](https://www.productsandservices.bt.com/broadband/smart-hub/) router to be queried for devices.
+Python package allowing for a [BT Smart Hub, BT Smart Hub 2](https://www.productsandservices.bt.com/broadband/smart-hub/) or [EE Smart Hub](https://shop.ee.co.uk/broadband/smart-hub) router to be queried for devices.
 The package will output either all devices stored in the router's memory or just the devices connected at present
 as a list of dicts with the following keys:
   - UserHostName (Device Name)
@@ -8,10 +8,10 @@ as a list of dicts with the following keys:
   - IPAddress (Last Known IP of Device)
   - Active (Boolean for if the Device is Connected to the Router)
   
-For use with a BT Smart Hub 2, set the smarthub_model flag to 2, for a BT Smart Hub 1 set the smarthub_model flag to 1. If you are not sure, leave the flag blank and it will attempt to determine the hub type.
+For use with a BT Smart Hub 2, set the smarthub_model flag to `2`, for a BT Smart Hub 1 set the smarthub_model flag to `1`, for an EE Smart Hub set the smarthub_model to `"EE"`. If you are not sure, leave the flag blank and it will attempt to determine the hub type.
 
 
-If the router is a BT Smart Hub 2 and you set the include_connections flag to True then the additional keys will additionally be populated:
+If the router is a BT Smart Hub 2 and you set the `include_connections` flag to `True` then the additional keys will additionally be populated:
  - ConnectionType (Ether | 2G | 5G  fixed/wifi 2.4Ghz/wifi 5Ghz)
  - ParentName (Name of parent device is connecting through - e.g. wifi disks name)
  - ParentPhysAddress ( MAC Address of the parent)
@@ -31,7 +31,7 @@ $ pip install btsmarthub_devicelist
 
 ### Example
 
-```sh
+```python
 from btsmarthub_devicelist import BTSmartHub
 smarthub = BTSmartHub(router_ip='192.168.1.254', smarthub_model=1)
 device_list = smarthub.get_devicelist(only_active_devices=True, include_connections=True)

--- a/btsmarthub_devicelist/__init__.py
+++ b/btsmarthub_devicelist/__init__.py
@@ -404,7 +404,7 @@ class BTSmartHub(object):
 
         # # we want to add how things are connected, and the parent info of what they connect through.
         # for device in devices:
-        if include_connections is True:
+        if self.smarthub_model == 2 and include_connections is True:
             # load the disks and stations...so we can enrich data.
             request_url = 'http://' + self.router_ip + '/cgi/cgi_owl.js'
             # use common method to pull body data for our url

--- a/tests/test_btsmarthub_devicelist.py
+++ b/tests/test_btsmarthub_devicelist.py
@@ -32,6 +32,13 @@ class TestBTSmartHub(unittest.TestCase):
         responses.add(responses.GET, 'http://smarthub2fakedrouter/cgi/cgi_basicMyDevice.js',
                       body=self.smarthubb2_cgi_basicMyDevice, status=200)
 
+    def setup_fake_eesmarthub(self):
+         # initialise mock - make sure EE smarthub 2 is ok....
+        responses.add(responses.GET, 'http://eesmarthubfakedrouter/cgi/cgi_basicMyDevice.js', status=404)
+        responses.add(responses.GET, 'http://eesmarthubfakedrouter/cgi/cgi_owl.js', status=404)
+        responses.add(responses.GET, 'http://eesmarthubfakedrouter/cgi/cgi_myNetwork.js',
+                      body=self.smarthubb2_cgi_basicMyDevice, status=200)
+
     @responses.activate
     def test_btsmarthub2_getdevicelist__no_active_flag_returns_only_active(self):
         self.setup_fake_smarthub2()
@@ -41,6 +48,14 @@ class TestBTSmartHub(unittest.TestCase):
         for device in devices:
             self.assertTrue( device.get("Active"))
 
+    @responses.activate
+    def test_eesmarthub_getdevicelist__no_active_flag_returns_only_active(self):
+        self.setup_fake_eesmarthub()
+
+        devices = BTSmartHub(router_ip='eesmarthubfakedrouter').get_devicelist()
+
+        for device in devices:
+            self.assertTrue( device.get("Active"))
 
     @responses.activate
     def test_btsmarthub2_getdevicelist_no_connection_details(self):
@@ -129,9 +144,20 @@ class TestBTSmartHub(unittest.TestCase):
         self.assertTrue(2 == BTSmartHub(router_ip="smarthub2fakedrouter").autodetect_smarthub_model())
 
     @responses.activate
+    def test_eesmarthub_with_mocked_eesmarthub_present(self):
+        # initialise mock - make sure smarthub 2 fails....
+        responses.add(responses.GET, 'http://eesmarthubfakedrouter/cgi/cgi_basicMyDevice.js', status=400)
+        # initialise mock - make sure EE smarthub fails....
+        responses.add(responses.GET, 'http://eesmarthubfakedrouter/cgi/cgi_myNetwork.js', status=200)
+
+        self.assertTrue("EE" == BTSmartHub(router_ip="eesmarthubfakedrouter").autodetect_smarthub_model())
+
+    @responses.activate
     def test_btsmarthub1_with_mocked_smarthub1_present(self):
         # initialise mock - make sure smarthub 2 fails....
         responses.add(responses.GET, 'http://smarthub1fakedrouter/cgi/cgi_basicMyDevice.js', status=400)
+        # initialise mock - make sure EE smarthub fails....
+        responses.add(responses.GET, 'http://smarthub1fakedrouter/cgi/cgi_myNetwork.js', status=400)
         # initialise mock - make sure smarthub 1 doesn't fail
         responses.add(responses.GET, 'http://smarthub1fakedrouter/gui/#/home/myNetwork/devices', status=200)
 


### PR DESCRIPTION
EE (which is owned by BT) also provide smart hubs and these are essentially the same hardware as BT Smart hubs, however the urls are a little different. This adds support for these hubs.

I also took the liberty to simplify some of the try..except logic to reduce the amount of indentation required.