### PR TITLE
Add Referer to requests, add missing Disc fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ $ pip install btsmarthub_devicelist
 from btsmarthub_devicelist import BTSmartHub
 smarthub = BTSmartHub(router_ip='192.168.1.254', smarthub_model=2)
 device_list = smarthub.get_devicelist(only_active_devices=True, include_connections=True)
-print(devicelist)
+print(device_list)
 ```
 

--- a/btsmarthub_devicelist/__init__.py
+++ b/btsmarthub_devicelist/__init__.py
@@ -333,7 +333,7 @@ class BTSmartHub(object):
             "sta_num", "connect_type", "connect_rssi", "model_name", "product_id",
             "node_lvid", "uptime", "connected_role", "connected_rootap", "linkrate", "node_num",
             "node_num_max", "linkmode", "sta_num_max", "cpuU", "cpuS", "cpuI", "memT", "memF", "memU", "proc_n",
-            "hub_status", "fud", "type", "lsd"]
+            "hub_status", "fud", "type", "lsd", "ether_speed", "ether_name"]
 
         # convert to json str
         json_data = self.extract_js_variable_to_json_string(owl_body, 'owl_tplg=', extension_labels)

--- a/btsmarthub_devicelist/__init__.py
+++ b/btsmarthub_devicelist/__init__.py
@@ -44,6 +44,8 @@ class BTSmartHub(object):
         else:
             self.smarthub_model = smarthub_model
 
+        self.referer = "http://{}/basic_-_my_devices.htm".format(self.router_ip)
+
     def get_devicelist(self, only_active_devices=None,include_connections=None):
 
         if only_active_devices is None:
@@ -221,7 +223,7 @@ class BTSmartHub(object):
         """
         # make request to the server
         try:
-            response = requests.get(url_to_read)
+            response = requests.get(url_to_read, headers={'Referer': self.referer})
         except requests.exceptions.Timeout:
             _LOGGER.exception("Connection to the router times out")
             return
@@ -318,7 +320,7 @@ class BTSmartHub(object):
             # load the disks and stations...so we can enrich data.
             request_url = 'http://' + self.router_ip + '/cgi/cgi_owl.js'
             # use common method to pull body data for our url
-            owl_body = self.get_body_content(request_url)
+            owl_body = self.get_body_content(request_url, headers={'Referer': self.referer})
 
 
         # labels in the extensions jscript


### PR DESCRIPTION
This PR adds Referer headers to requests, as required in later versions of the BT SmartHub2 (as has been reported by people using Home Assistant). This should fix https://github.com/jxwolstenholme/btsmarthub_devicelist/issues/15 and a new release afterwards could be used to fix https://github.com/home-assistant/core/issues/59653, https://github.com/home-assistant/core/issues/66945, and https://github.com/home-assistant/core/issues/77513.

This also adds a couple of missing fields to the BT WiFi Disc info parsing, which was causing errors while testing using the example code in the README.