### PR TITLE
Add referer header when autodetecting SmartHub 2

### DIFF
--- a/btsmarthub_devicelist/__init__.py
+++ b/btsmarthub_devicelist/__init__.py
@@ -39,12 +39,12 @@ class BTSmartHub(object):
         else:
             self.router_ip = DEFAULT_IP
 
+        self.referer = "http://{}/basic_-_my_devices.htm".format(self.router_ip)
+
         if not smarthub_model:
             self.smarthub_model = self.autodetect_smarthub_model()
         else:
             self.smarthub_model = smarthub_model
-
-        self.referer = "http://{}/basic_-_my_devices.htm".format(self.router_ip)
 
     def get_devicelist(self, only_active_devices=None,include_connections=None):
 
@@ -467,7 +467,7 @@ class BTSmartHub(object):
         # First try to determine if router is Smarthub 2
         try:
             request_url = 'http://' + self.router_ip + '/cgi/cgi_basicMyDevice.js'
-            response = requests.get(request_url, timeout=wait_time)
+            response = requests.get(request_url, timeout=wait_time, headers={'Referer': self.referer})
             response.raise_for_status()
             if response.status_code == 200:
                 _LOGGER.info("Router (%s) appears to be a Smart Hub 2 ", self.router_ip)


### PR DESCRIPTION
My previous PR missed a request during autodetecting which SmartHub is being talked to. The current workaround in Home Assistant is to specify the version, but this PR will correct the issue so users don't need to do this.

Obviously a new version will need to be published to downstream it to Home Assistant.